### PR TITLE
Fix instrument:addVoice param from _Vector2D to _Synth

### DIFF
--- a/playdate.luars
+++ b/playdate.luars
@@ -1159,7 +1159,7 @@ fun playdate.sound.fileplayer:stop(): nil;
 global playdate.sound.instrument: _SoundSource;
 fun playdate.sound.instrument.new(synth?: _Synth): _Instrument;
 local _Instrument: playdate.sound.instrument;
-fun playdate.sound.instrument:addVoice(v: _Vector2D, note?: integer, rangeend?: integer, transpose?: integer): nil;
+fun playdate.sound.instrument:addVoice(v: _Synth, note?: integer, rangeend?: integer, transpose?: integer): nil;
 fun playdate.sound.instrument:allNotesOff(): nil;
 fun playdate.sound.instrument:getVolume(): (left_or_mono: number, right: number?);
 fun playdate.sound.instrument:noteOff(note: integer, when?: number): nil;

--- a/stub.lua
+++ b/stub.lua
@@ -4277,7 +4277,7 @@ function playdate.sound.fileplayer:stop() end
 ---@return _Instrument
 function playdate.sound.instrument.new(synth) end
 
----@param v _Vector2D
+---@param v _Synth
 ---@param note? integer
 ---@param rangeend? integer
 ---@param transpose? integer


### PR DESCRIPTION
Given the Playdate Lua SDK documentation, it's my understanding that the first argument to `instrument:addVoice` should be of type `_Synth` rather than `_Vector2D`. This is currently showing as a mismatch in my uses of the function in VSCode, but this PR should fix it.

Thanks for setting up this project, it's very useful!