### PR TITLE
Add value timer properties and change scale argument types

### DIFF
--- a/playdate.luars
+++ b/playdate.luars
@@ -210,7 +210,16 @@ local _FrameTimer: playdate.frameTimer = {
     frame: integer,
     repeats: boolean,
     reverses: boolean,
+    timerEndedCallback: function,
     timerEndedArgs: any[],
+    updateCallback: function,
+    value: number,
+    startValue: number,
+    endValue: number,
+    easingFunction: function,
+    easingAmplitude: number,
+    easingPeriod: number,
+    reverseEasingFunction: function
 };
 fun _FrameTimer:timerEndedCallback(...: any): nil;
 fun _FrameTimer:updateCallback(...: any): nil;
@@ -639,9 +648,9 @@ fun playdate.graphics.image:drawCentered(x: integer, y: integer, flip?: (integer
 fun playdate.graphics.image:drawFaded(x: integer, y: integer, alpha: number, ditherType: integer): nil;
 fun playdate.graphics.image:drawIgnoringOffset(p: _Point, flip?: (integer|string)): nil;
 fun playdate.graphics.image:drawIgnoringOffset(x: integer, y: integer, flip?: (integer|string)): nil;
-fun playdate.graphics.image:drawRotated(x: integer, y: integer, angle: number, scale?: integer, yscale?: integer): nil;
+fun playdate.graphics.image:drawRotated(x: integer, y: integer, angle: number, scale?: number, yscale?: number): nil;
 fun playdate.graphics.image:drawSampled(x: integer, y: integer, width: integer, height: integer, centerx: number, centery: number, dxx: number, dyx: number, dxy: number, dyy: number, dx: integer, dy: integer, z: integer, tiltAngle: number, tile: boolean): nil;
-fun playdate.graphics.image:drawScaled(x: integer, y: integer, scale: integer, yscale?: integer): nil;
+fun playdate.graphics.image:drawScaled(x: integer, y: integer, scale: number, yscale?: number): nil;
 fun playdate.graphics.image:drawTiled(rect: _Rect, flip?: (integer|string)): nil;
 fun playdate.graphics.image:drawTiled(x: integer, y: integer, width: integer, height: integer, flip?: (integer|string)): nil;
 fun playdate.graphics.image:drawWithTransform(xform: _AffineTransform, x: integer, y: integer): nil;
@@ -652,9 +661,9 @@ fun playdate.graphics.image:hasMask(): boolean;
 fun playdate.graphics.image:invertedImage(): _Image;
 fun playdate.graphics.image:load(path: string): (success: boolean, error: string?);
 fun playdate.graphics.image:removeMask(): nil;
-fun playdate.graphics.image:rotatedImage(angle: number, scale?: integer, yscale?: integer): _Image;
+fun playdate.graphics.image:rotatedImage(angle: number, scale?: number, yscale?: number): _Image;
 fun playdate.graphics.image:sample(x: integer, y: integer): integer;
-fun playdate.graphics.image:scaledImage(scale: integer, yscale?: integer): _Image;
+fun playdate.graphics.image:scaledImage(scale: number, yscale?: number): _Image;
 fun playdate.graphics.image:setInverted(flag: boolean): nil;
 fun playdate.graphics.image:setMaskImage(maskImage: _Image): nil;
 fun playdate.graphics.image:transformedImage(xform: _AffineTransform): _Image;
@@ -773,7 +782,7 @@ fun playdate.graphics.sprite:resetGroupMask(): nil;
 fun playdate.graphics.sprite:setAnimator(animator: _Animator, moveWithCollisions?: boolean, removeOnCollision?: boolean): nil;
 fun playdate.graphics.sprite:setBounds(rect: _Rect): nil;
 fun playdate.graphics.sprite:setBounds(x: integer, y: integer, width: integer, height: integer): nil;
-fun playdate.graphics.sprite:setCenter(x: integer, y: integer): nil;
+fun playdate.graphics.sprite:setCenter(x: number, y: number): nil;
 fun playdate.graphics.sprite:setClipRect(rect: _Rect): nil;
 fun playdate.graphics.sprite:setClipRect(x: integer, y: integer, width: integer, height: integer): nil;
 fun playdate.graphics.sprite:setCollideRect(rect: _Rect): nil;
@@ -1314,7 +1323,16 @@ local _Timer: playdate.timer = {
     paused: boolean,
     repeats: boolean,
     reverses: boolean,
+    timerEndedCallback: function,
     timerEndedArgs: any[],
+    updateCallback: function,
+    value: number,
+    startValue: number,
+    endValue: number,
+    easingFunction: function,
+    easingAmplitude: number,
+    easingPeriod: number,
+    reverseEasingFunction: function
 };
 fun _Timer:timerEndedCallback(...: any): nil;
 fun _Timer:updateCallback(...: any): nil;

--- a/stub.lua
+++ b/stub.lua
@@ -402,7 +402,16 @@ local _Font = {}
 ---@field frame integer
 ---@field repeats boolean
 ---@field reverses boolean
+---@field timerEndedCallback function
 ---@field timerEndedArgs any[]
+---@field updateCallback function
+---@field value number
+---@field startValue number
+---@field endValue number
+---@field easingFunction function
+---@field easingAmplitude number
+---@field easingPeriod number
+---@field reverseEasingFunction function
 local _FrameTimer = {}
 
 ---@class _GridView : playdate.ui.gridview
@@ -683,7 +692,16 @@ local _TileMap = {}
 ---@field paused boolean
 ---@field repeats boolean
 ---@field reverses boolean
+---@field timerEndedCallback function
 ---@field timerEndedArgs any[]
+---@field updateCallback function
+---@field value number
+---@field startValue number
+---@field endValue number
+---@field easingFunction function
+---@field easingAmplitude number
+---@field easingPeriod number
+---@field reverseEasingFunction function
 local _Timer = {}
 
 ---@class _Track : playdate.sound.track
@@ -2938,8 +2956,8 @@ function playdate.graphics.image:drawIgnoringOffset(p, flip) end
 ---@param x integer
 ---@param y integer
 ---@param angle number
----@param scale? integer
----@param yscale? integer
+---@param scale? number
+---@param yscale? number
 ---@return nil
 function playdate.graphics.image:drawRotated(x, y, angle, scale, yscale) end
 
@@ -2963,8 +2981,8 @@ function playdate.graphics.image:drawSampled(x, y, width, height, centerx, cente
 
 ---@param x integer
 ---@param y integer
----@param scale integer
----@param yscale? integer
+---@param scale number
+---@param yscale? number
 ---@return nil
 function playdate.graphics.image:drawScaled(x, y, scale, yscale) end
 
@@ -3014,8 +3032,8 @@ function playdate.graphics.image:load(path) end
 function playdate.graphics.image:removeMask() end
 
 ---@param angle number
----@param scale? integer
----@param yscale? integer
+---@param scale? number
+---@param yscale? number
 ---@return _Image
 function playdate.graphics.image:rotatedImage(angle, scale, yscale) end
 
@@ -3024,8 +3042,8 @@ function playdate.graphics.image:rotatedImage(angle, scale, yscale) end
 ---@return integer
 function playdate.graphics.image:sample(x, y) end
 
----@param scale integer
----@param yscale? integer
+---@param scale number
+---@param yscale? number
 ---@return _Image
 function playdate.graphics.image:scaledImage(scale, yscale) end
 
@@ -3438,8 +3456,8 @@ function playdate.graphics.sprite:setBounds(x, y, width, height) end
 ---@return nil
 function playdate.graphics.sprite:setBounds(rect) end
 
----@param x integer
----@param y integer
+---@param x number
+---@param y number
 ---@return nil
 function playdate.graphics.sprite:setCenter(x, y) end
 


### PR DESCRIPTION
Here's one more I came across.

This PR mainly adds properties for Value Timers. I'm not sure if they were left out on purpose (if so please correct me), perhaps they're a bit of an odd case because they have their own sections in the docs, but not their own class, instead relying on the standard Timer and FrameTimer classes. I'm not sure if the two callback functions are redundant in this case, since they're already listed as class functions.

Next, this PR also changes the type of:

- the `scale` arguments for a few functions where it makes sense that they would be a `number` (as opposed to, say, `display.setScale` which accepts a limited number of `integer` values)
- the arguments to `sprite:setCenter`, which the docs say should go from 0.0 to 1.0 (representing a fraction of width and height rather than being coordinates)

Let me know what you think!
